### PR TITLE
Allow overriding cucumber_steps_glob definition for local requirements

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,24 @@ corresponding step definition and replaces the current buffer. `<C-W>d` or
 the cursor there. `[d` or `]d` on a step opens the step definition in a new
 split buffer while maintaining the current cursor position.
 
+## Runtime Options
+
+vim-cucumber looks through steps defined in your 'features' or 'stories' folder.
+Usually this is OK, but if you work in a multi-project environment, where each
+project has its own sub-folder, this can lead to many occurences of 'Multiple 
+matching steps...' and extra work to find the step that your project uses.
+
+To avoid this situation, you can export the CUKEFILES environment variable as a
+glob specification, which will then be used in place of the default.  An example
+would be:
+
+  export CUKEFILES='/Users/jesii/features/step\_definitions/mobweb/\*\*/\*.rb'
+
+## Documentation
+
+Standard vim documentation is available through:
+  :h vim-cucumber
+
 ## Installation
 
 If you don't have a preferred installation method, I recommend installing

--- a/doc/vim-cucumber.txt
+++ b/doc/vim-cucumber.txt
@@ -1,0 +1,32 @@
+*vim-cucumber.txt*  Simple docs for those of us suffering from CRS
+
+Author: Jonathan Seidel <http://www.edpci.com>
+License: Same terms as vim itself ( see |license|)
+
+INTRODUCTION                              *vim-cucumber*
+
+When working with cucumber, several useful commands are defined
+that let you work with feature files and step definitions seamlessly.
+
+MAPPINGS                                  *vim-cucumber-mappings*
+
+These mappings are available in your local buffers.
+
+                                          *vim-cucumber_[<CTRL-d>*
+                                          *vim-cucumber_]<CTRL-d>*
+[<C-d>            on a step jumps to the corresponding step definition and 
+]<C-d>            replaces the current buffer.
+
+                                          *vim-cucumber_<CTRL-W>d*
+                                          *vim-cucumber_<CTRL-W><CTRL-d>*
+<C-W>d            on a step jumps to its definition in a new split buffer
+<C-w><C-d>        and moves the cursor there.
+
+                                          *vim-cucumber_[d*
+                                          *vim-cucumber_]d*
+[d                on a step jumps to its definition in a new split buffer
+]d                while maintaining the current cursor position.
+
+                                          *vim-cucumber_<CTRL-^>*
+<C-^>             Return from the step definition to the feature file
+                  after having used the [<C-d> mapping.

--- a/ftplugin/cucumber.vim
+++ b/ftplugin/cucumber.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Cucumber
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
-" Last Change:	2013 Jun 01
+" Last Change: 2016 May 28
 
 " Only do this when not done yet for this buffer
 if (exists("b:did_ftplugin"))
@@ -18,9 +18,19 @@ setlocal omnifunc=CucumberComplete
 
 let b:undo_ftplugin = "setl fo< com< cms< ofu<"
 
+" Allow setting the cucumber-root to a different value,
+" via ENV variable CUKEFILES
+" This is the default
 let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
+
 if !exists("b:cucumber_steps_glob")
-  let b:cucumber_steps_glob = b:cucumber_root.'/**/*.rb'
+  if empty($CUKEFILES)
+    echom "Using default definition for b:cucumber_steps_glob"
+    let b:cucumber_steps_glob = b:cucumber_root.'/**/*.rb'
+  else
+    echom 'Using CUKEFILES environment variable for b:cucumber_steps_glob'
+    let b:cucumber_steps_glob = $CUKEFILES
+  endif
 endif
 
 if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
@@ -45,7 +55,7 @@ function! s:jump(command,count)
   if len(steps) == 0 || len(steps) < a:count
     return 'echoerr "No matching step found"'
   elseif len(steps) > 1 && !a:count
-    return 'echoerr "Multiple matching steps found"'
+    return 'echoerr "Multiple matching steps (" . len(steps) . ") found"'
   else
     let c = a:count ? a:count-1 : 0
     return a:command.' +'.steps[c][1].' '.escape(steps[c][0],' %#')

--- a/ftplugin/cucumber.vim
+++ b/ftplugin/cucumber.vim
@@ -20,7 +20,12 @@ let b:undo_ftplugin = "setl fo< com< cms< ofu<"
 
 " let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
 let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)/step_definitions/mobile_website\zs[\/].*??')
-echo 'cucumber_root = ' + b:cucumber_root
+" let b:cucumber_root = expand('/Users/yc98js1/dev/QAA/features/step_definitions/mobile_website/.*??')
+echom 'cucumber_root = ' . b:cucumber_root
+function! VimCucumberRoot(root)
+  return root
+endfunction
+command! VimCucumberRoot :call VimCucumberRoot(b:cucumber_root))
 
 if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
   cnoremap <SID>foldopen <Bar>if &foldopen =~# 'tag'<Bar>exe 'norm! zv'<Bar>endif
@@ -39,9 +44,6 @@ if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
         \ "|sil! nunmap <buffer> ]d"
 endif
 
-function! VimCucumberRoot()
-  echo 'cucumber_root = ' + b:cucumber_root
-endfunction
 function! s:jump(command,count)
   let steps = s:steps('.')
   if len(steps) == 0 || len(steps) < a:count

--- a/ftplugin/cucumber.vim
+++ b/ftplugin/cucumber.vim
@@ -18,7 +18,9 @@ setlocal omnifunc=CucumberComplete
 
 let b:undo_ftplugin = "setl fo< com< cms< ofu<"
 
-let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
+" let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
+let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)/step_definitions/mobile_website/\zs[\/].*??')
+echo b:cucumber_root
 
 if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
   cnoremap <SID>foldopen <Bar>if &foldopen =~# 'tag'<Bar>exe 'norm! zv'<Bar>endif

--- a/ftplugin/cucumber.vim
+++ b/ftplugin/cucumber.vim
@@ -18,9 +18,7 @@ setlocal omnifunc=CucumberComplete
 
 let b:undo_ftplugin = "setl fo< com< cms< ofu<"
 
-" let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
-let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)/step_definitions/mobile_website/\zs[\/].*??')
-echo b:cucumber_root
+let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
 
 if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
   cnoremap <SID>foldopen <Bar>if &foldopen =~# 'tag'<Bar>exe 'norm! zv'<Bar>endif

--- a/ftplugin/cucumber.vim
+++ b/ftplugin/cucumber.vim
@@ -18,7 +18,9 @@ setlocal omnifunc=CucumberComplete
 
 let b:undo_ftplugin = "setl fo< com< cms< ofu<"
 
-let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
+" let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)\zs[\/].*??')
+let b:cucumber_root = expand('%:p:h:s?.*[\/]\%(features\|stories\)/step_definitions/mobile_website\zs[\/].*??')
+echo 'cucumber_root = ' + b:cucumber_root
 
 if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
   cnoremap <SID>foldopen <Bar>if &foldopen =~# 'tag'<Bar>exe 'norm! zv'<Bar>endif
@@ -37,6 +39,9 @@ if !exists("g:no_plugin_maps") && !exists("g:no_cucumber_maps")
         \ "|sil! nunmap <buffer> ]d"
 endif
 
+function! VimCucumberRoot()
+  echo 'cucumber_root = ' + b:cucumber_root
+endfunction
 function! s:jump(command,count)
   let steps = s:steps('.')
   if len(steps) == 0 || len(steps) < a:count


### PR DESCRIPTION
Allow overriding the default glob definition for b:cucumber_steps_glob by exporting the CUKEFILES environment variable. As noted in the updated README file, this can be necessary when working in a large, multi-project environment when each project has it's own features/step_definitions/<subfolder> where steps specific to that project are stored. 

My working environment has half a dozen such projects and I was receiving many "Multiple matching steps..." error messages because of similar SDs for the different projects. Our cucumber yml files took care of use through different profiles for each project, the vim-cucumber bundled them all together with the default glob definition.

(NOTE: I've squashed all the commits in my local project and pushed to this branch, but there are still multiple commits included here... not sure why, but I'm happy to fix if that's needed.)